### PR TITLE
GH-38: fix query error in uninstall.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: WebAuthn Provider for Two Factor
  * Description: WebAuthn Provider for Two Factor plugin.
- * Version: 1.0.1
+ * Version: 1.0.3
  * Author: Volodymyr Kolesnykov
  * License: MIT
  * Text Domain: two-factor-provider-webauthn

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,12 +8,15 @@ use WildWolf\WordPress\TwoFactorWebAuthn\Settings;
 use WildWolf\WordPress\TwoFactorWebAuthn\WebAuthn_Provider;
 
 /**
+ * @global wpdb $wpdb
  * @var wpdb $wpdb
  * @psalm-suppress InvalidGlobal
  */
 global $wpdb;
 
 if ( defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	require __DIR__ . '/vendor/autoload.php';
+	Schema::instance();
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->webauthn_credentials}" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->webauthn_users}" );
 	delete_option( Schema::VERSION_KEY );


### PR DESCRIPTION
When the plugin is inactive, `Schema.php` is not loaded. As a consequence, `$wpdb->webauthn_credentials` and `$wpdb->webauthn_users` are not set.
