### PR TITLE
GH-38: uninstall should work even with inactive Two Factor plugin

### DIFF
--- a/inc/class-ajax.php
+++ b/inc/class-ajax.php
@@ -14,7 +14,7 @@ use WP_User;
 final class AJAX {
 	use Singleton;
 
-	const REGISTRATION_CONTEXT_USER_META = '_webauthn_registration_context';
+	public const REGISTRATION_CONTEXT_USER_META = Constants::REGISTRATION_CONTEXT_USER_META_KEY;
 
 	private function __construct() {
 		$this->admin_init();

--- a/inc/class-constants.php
+++ b/inc/class-constants.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace WildWolf\WordPress\TwoFactorWebAuthn;
+
+abstract class Constants {
+	public const SCHEMA_VERSION_KEY                   = '2fa-wa-schema-version';
+	public const OPTIONS_KEY                          = '2fa_webauthn_settings';
+	public const REGISTRATION_CONTEXT_USER_META_KEY   = '_webauthn_registration_context';
+	public const AUTHENTICATION_CONTEXT_USER_META_KEY = '_webauthn_auth_context';
+	public const WA_CREDENTIALS_TABLE_NAME            = '2fa_webauthn_credentials';
+	public const WA_USERS_TABLE_NAME                  = '2fa_webauthn_users';
+}

--- a/inc/class-schema.php
+++ b/inc/class-schema.php
@@ -8,7 +8,7 @@ use wpdb;
 final class Schema {
 	use Singleton;
 
-	public const VERSION_KEY    = '2fa-wa-schema-version';
+	public const VERSION_KEY    = Constants::SCHEMA_VERSION_KEY;
 	public const LATEST_VERSION = 1;
 
 	/**
@@ -18,8 +18,8 @@ final class Schema {
 		/** @var wpdb $wpdb */
 		global $wpdb;
 
-		$wpdb->webauthn_credentials = $wpdb->prefix . '2fa_webauthn_credentials';
-		$wpdb->webauthn_users       = $wpdb->prefix . '2fa_webauthn_users';
+		$wpdb->webauthn_credentials = $wpdb->prefix . Constants::WA_CREDENTIALS_TABLE_NAME;
+		$wpdb->webauthn_users       = $wpdb->prefix . Constants::WA_USERS_TABLE_NAME;
 	}
 
 	public function is_installed(): bool {

--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -20,7 +20,7 @@ final class Settings implements ArrayAccess {
 	use Singleton;
 
 	/** @var string  */
-	public const OPTIONS_KEY = '2fa_webauthn_settings';
+	public const OPTIONS_KEY = Constants::OPTIONS_KEY;
 
 	/**
 	 * @psalm-readonly

--- a/inc/class-webauthn-provider.php
+++ b/inc/class-webauthn-provider.php
@@ -15,7 +15,7 @@ use UnexpectedValueException;
 use WP_User;
 
 class WebAuthn_Provider extends Two_Factor_Provider {
-	public const AUTHENTICATION_CONTEXT_USER_META = '_webauthn_auth_context';
+	public const AUTHENTICATION_CONTEXT_USER_META = Constants::AUTHENTICATION_CONTEXT_USER_META_KEY;
 
 	/** @var static|null */
 	private static $instance = null;

--- a/uninstall.php
+++ b/uninstall.php
@@ -2,10 +2,7 @@
 
 // phpcs:disable WordPress.DB.DirectDatabaseQuery
 
-use WildWolf\WordPress\TwoFactorWebAuthn\AJAX;
-use WildWolf\WordPress\TwoFactorWebAuthn\Schema;
-use WildWolf\WordPress\TwoFactorWebAuthn\Settings;
-use WildWolf\WordPress\TwoFactorWebAuthn\WebAuthn_Provider;
+use WildWolf\WordPress\TwoFactorWebAuthn\Constants;
 
 /**
  * @global wpdb $wpdb
@@ -15,12 +12,15 @@ use WildWolf\WordPress\TwoFactorWebAuthn\WebAuthn_Provider;
 global $wpdb;
 
 if ( defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-	require __DIR__ . '/vendor/autoload.php';
-	Schema::instance();
+	require_once __DIR__ . '/inc/class-constants.php';
+
+	$wpdb->webauthn_credentials = $wpdb->prefix . Constants::WA_CREDENTIALS_TABLE_NAME;
+	$wpdb->webauthn_users       = $wpdb->prefix . Constants::WA_USERS_TABLE_NAME;
+
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->webauthn_credentials}" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->webauthn_users}" );
-	delete_option( Schema::VERSION_KEY );
-	delete_option( Settings::OPTIONS_KEY );
-	delete_metadata( 'user', 0, AJAX::REGISTRATION_CONTEXT_USER_META, null, true );
-	delete_metadata( 'user', 0, WebAuthn_Provider::AUTHENTICATION_CONTEXT_USER_META, null, true );
+	delete_option( Constants::SCHEMA_VERSION_KEY );
+	delete_option( Constants::OPTIONS_KEY );
+	delete_metadata( 'user', 0, Constants::REGISTRATION_CONTEXT_USER_META_KEY, null, true );
+	delete_metadata( 'user', 0, Constants::AUTHENTICATION_CONTEXT_USER_META_KEY, null, true );
 }


### PR DESCRIPTION
If the Two Factor plugin is inactive, uninstall fails when trying to load the `WebAuthn_Provider` class because it inherits from unloadable `Two_Factor_Provider`.
