### PR TITLE
GH-33: increase length of credential_id column

### DIFF
--- a/inc/class-ajax.php
+++ b/inc/class-ajax.php
@@ -6,7 +6,6 @@ use InvalidArgumentException;
 use MadWizard\WebAuthn\Json\JsonConverter;
 use MadWizard\WebAuthn\Server\Registration\RegistrationContext;
 use MadWizard\WebAuthn\Server\Registration\RegistrationOptions;
-use RuntimeException;
 use Throwable;
 use UnexpectedValueException;
 use WildWolf\Utils\Singleton;
@@ -108,7 +107,7 @@ final class AJAX {
 				$store = new WebAuthn_Credential_Store();
 				$key   = $store->save_user_key( $name, $result );
 				if ( null === $key ) {
-					throw new RuntimeException( __( 'Unable to save the key to the database.', 'two-factor-provider-webauthn' ) );
+					throw new UnexpectedValueException( __( 'Unable to save the key to the database.', 'two-factor-provider-webauthn' ) );
 				}
 
 				$table = new Key_Table( $user );

--- a/inc/class-ajax.php
+++ b/inc/class-ajax.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use MadWizard\WebAuthn\Json\JsonConverter;
 use MadWizard\WebAuthn\Server\Registration\RegistrationContext;
 use MadWizard\WebAuthn\Server\Registration\RegistrationOptions;
+use RuntimeException;
 use Throwable;
 use UnexpectedValueException;
 use WildWolf\Utils\Singleton;
@@ -106,6 +107,9 @@ final class AJAX {
 				$name  = sanitize_text_field( (string) ( $_POST['name'] ?? '' ) );
 				$store = new WebAuthn_Credential_Store();
 				$key   = $store->save_user_key( $name, $result );
+				if ( null === $key ) {
+					throw new RuntimeException( __( 'Unable to save the key to the database.', 'two-factor-provider-webauthn' ) );
+				}
 
 				$table = new Key_Table( $user );
 				ob_start();

--- a/inc/class-schema.php
+++ b/inc/class-schema.php
@@ -9,7 +9,7 @@ final class Schema {
 	use Singleton;
 
 	public const VERSION_KEY    = Constants::SCHEMA_VERSION_KEY;
-	public const LATEST_VERSION = 1;
+	public const LATEST_VERSION = 2;
 
 	/**
 	 * @global wpdb $wpdb
@@ -71,7 +71,7 @@ final class Schema {
 			"CREATE TABLE {$wpdb->webauthn_credentials} (
 				id bigint(20) unsigned NOT NULL auto_increment,
 				user_handle varchar(128) NOT NULL,
-				credential_id varchar(128) NOT NULL,
+				credential_id varchar(767) CHARSET ascii COLLATE ascii_bin NOT NULL,
 				public_key varchar(255) NOT NULL,
 				counter int(11) NOT NULL,
 				name varchar(255) NOT NULL,

--- a/inc/class-webauthn-credential-store.php
+++ b/inc/class-webauthn-credential-store.php
@@ -105,10 +105,10 @@ class WebAuthn_Credential_Store implements CredentialStoreInterface {
 	}
 
 	/**
-	 * @psalm-return CredentialRowArray
+	 * @psalm-return CredentialRowArray|null
 	 * @global wpdb $wpdb
 	 */
-	public function save_user_key( string $key_name, RegistrationResultInterface $result ): array {
+	public function save_user_key( string $key_name, RegistrationResultInterface $result ): ?array {
 		/** @var wpdb $wpdb */
 		global $wpdb;
 
@@ -124,8 +124,8 @@ class WebAuthn_Credential_Store implements CredentialStoreInterface {
 			'u2f'           => 0,
 		];
 
-		$wpdb->insert( $wpdb->webauthn_credentials, $credential, [ '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%d' ] );
-		return $credential;
+		$result = $wpdb->insert( $wpdb->webauthn_credentials, $credential, [ '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%d' ] );
+		return false !== $result ? $credential : null;
 	}
 
 	/**

--- a/inc/class-webauthn-user.php
+++ b/inc/class-webauthn-user.php
@@ -5,7 +5,7 @@ namespace WildWolf\WordPress\TwoFactorWebAuthn;
 use MadWizard\WebAuthn\Credential\UserHandle;
 use MadWizard\WebAuthn\Exception\NotAvailableException;
 use MadWizard\WebAuthn\Server\UserIdentityInterface;
-use RuntimeException;
+use UnexpectedValueException;
 use WP_User;
 use wpdb;
 
@@ -49,7 +49,7 @@ class WebAuthn_User implements UserIdentityInterface {
 				);
 
 				if ( false === $result ) {
-					throw new RuntimeException( __( 'Unable to save the user handle to the database.', 'two-factor-provider-webauthn' ) );
+					throw new UnexpectedValueException( __( 'Unable to save the user handle to the database.', 'two-factor-provider-webauthn' ) );
 				}
 			}
 

--- a/inc/class-webauthn-user.php
+++ b/inc/class-webauthn-user.php
@@ -5,6 +5,7 @@ namespace WildWolf\WordPress\TwoFactorWebAuthn;
 use MadWizard\WebAuthn\Credential\UserHandle;
 use MadWizard\WebAuthn\Exception\NotAvailableException;
 use MadWizard\WebAuthn\Server\UserIdentityInterface;
+use RuntimeException;
 use WP_User;
 use wpdb;
 
@@ -38,7 +39,7 @@ class WebAuthn_User implements UserIdentityInterface {
 			$handle = $wpdb->get_var( $wpdb->prepare( "SELECT user_handle FROM {$wpdb->webauthn_users} WHERE user_id = %d", $this->user->ID ) );
 			if ( ! $handle ) {
 				$handle = UserHandle::random()->toString();
-				$wpdb->insert(
+				$result = $wpdb->insert(
 					$wpdb->webauthn_users,
 					[
 						'user_id'     => $this->user->ID,
@@ -46,6 +47,10 @@ class WebAuthn_User implements UserIdentityInterface {
 					],
 					[ '%d', '%s' ]
 				);
+
+				if ( false === $result ) {
+					throw new RuntimeException( __( 'Unable to save the user handle to the database.', 'two-factor-provider-webauthn' ) );
+				}
 			}
 
 			wp_cache_set( $key, $handle, self::CACHE_GROUP_NAME, 3600 );

--- a/lang/two-factor-provider-webauthn-ru_RU.po
+++ b/lang/two-factor-provider-webauthn-ru_RU.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: WebAuthn Provider for Two Factor 1.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/two-factor-"
 "provider-webauthn\n"
-"POT-Creation-Date: 2022-01-28T06:26:54+02:00\n"
+"POT-Creation-Date: 2022-02-21T21:24:41+02:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,7 +103,9 @@ msgstr "Таймаут"
 msgid ""
 "The default timeout for security key operations, in seconds. Set to 0 to use "
 "the browser default value."
-msgstr "Значение таймаута для операций с ключами безопасности по умолчанию (в секундах). Установите в 0 для использования значения браузера по умолчанию."
+msgstr ""
+"Значение таймаута для операций с ключами безопасности по умолчанию (в "
+"секундах). Установите в 0 для использования значения браузера по умолчанию."
 
 #: inc/class-adminsettings.php:110
 msgid "U2F compatibility hack"
@@ -122,26 +124,31 @@ msgstr ""
 "зарегистрирован при помощи U2F; если да, то поддержка AppID включается "
 "принудительно."
 
-#: inc/class-ajax.php:32
+#: inc/class-ajax.php:33
 msgid "The nonce has expired. Please reload the page and try again."
 msgstr ""
 "Срок действия одноразового номера истёк. Пожалуйста, обновите страницу и "
 "попытайтесь выполнить действие снова."
 
-#: inc/class-ajax.php:84
+#: inc/class-ajax.php:85
 msgid "Unable to retrieve the registration context."
 msgstr "Не удалось получить контекст регистрации."
 
-#: inc/class-ajax.php:94 inc/class-ajax.php:120
+#: inc/class-ajax.php:95 inc/class-ajax.php:124
 #: inc/class-webauthn-provider.php:118
 msgid "Bad request."
 msgstr "Неверный запрос."
 
-#: inc/class-ajax.php:147
+#: inc/class-ajax.php:111
+#, fuzzy
+msgid "Unable to save the key to the database."
+msgstr "Не удалось получить контекст регистрации."
+
+#: inc/class-ajax.php:151
 msgid "Key name cannot be empty."
 msgstr "Имя ключа не может быть пустым."
 
-#: inc/class-ajax.php:156
+#: inc/class-ajax.php:160
 msgid "Failed to rename the key."
 msgstr "Не удалось переименовать ключ."
 
@@ -190,6 +197,10 @@ msgstr ""
 msgid "Unable to retrieve the authentication context."
 msgstr "Не удалось получить контекст аутентификации."
 
+#: inc/class-webauthn-user.php:52
+msgid "Unable to save the user handle to the database."
+msgstr ""
+
 #: views/login.php:2
 msgid "Please insert (and tap) your security key."
 msgstr "Пожалуйста, вставьте и коснитесь ключа безопасности."
@@ -199,7 +210,10 @@ msgid ""
 "Requires an HTTPS connection. Please configure your security keys in the <a "
 "href=\"#webauthn-security-keys-section\">Security Keys (WebAuthn)</a> "
 "section below."
-msgstr "Требуется безопасное соединение (HTTPS). Для управления ключами воспользуйтесь секцией <a href=\"#webauthn-security-keys-section\">Ключи безопасности (WebAuthn)</a>"
+msgstr ""
+"Требуется безопасное соединение (HTTPS). Для управления ключами "
+"воспользуйтесь секцией <a href=\"#webauthn-security-keys-section\">Ключи "
+"безопасности (WebAuthn)</a>"
 
 #: views/user-profile.php:10
 msgid "Security Keys (WebAuthn)"
@@ -213,7 +227,9 @@ msgstr "Для управления ключами безопасности не
 msgid ""
 "WebAuthn requires an HTTPS connection. You will be unable to add new "
 "security keys over HTTP."
-msgstr "Для WebAuthn требуется соединение HTTPS. Добавление новых ключей по HTTP невозможно."
+msgstr ""
+"Для WebAuthn требуется соединение HTTPS. Добавление новых ключей по HTTP "
+"невозможно."
 
 #: views/user-profile.php:28
 msgid "Key name:"

--- a/lang/two-factor-provider-webauthn.pot
+++ b/lang/two-factor-provider-webauthn.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: WebAuthn Provider for Two Factor 1.0.0\n"
+"Project-Id-Version: WebAuthn Provider for Two Factor 1.0.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/two-factor-provider-webauthn\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-01-28T06:32:00+02:00\n"
+"POT-Creation-Date: 2022-02-21T21:24:41+02:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.5.0\n"
+"X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: two-factor-provider-webauthn\n"
 
 #. Plugin Name of the plugin
@@ -96,25 +96,29 @@ msgstr ""
 msgid "Chrome for Android sometimes ignores the AppID extension required for interoperability between the old U2F and the modern WebAuthn protocol.<br/>When enabled, this hack enables the check whether the security key used was registered with U2F and if so, forces the use of the AppID extension."
 msgstr ""
 
-#: inc/class-ajax.php:32
+#: inc/class-ajax.php:33
 msgid "The nonce has expired. Please reload the page and try again."
 msgstr ""
 
-#: inc/class-ajax.php:84
+#: inc/class-ajax.php:85
 msgid "Unable to retrieve the registration context."
 msgstr ""
 
-#: inc/class-ajax.php:94
-#: inc/class-ajax.php:120
+#: inc/class-ajax.php:95
+#: inc/class-ajax.php:124
 #: inc/class-webauthn-provider.php:118
 msgid "Bad request."
 msgstr ""
 
-#: inc/class-ajax.php:147
+#: inc/class-ajax.php:111
+msgid "Unable to save the key to the database."
+msgstr ""
+
+#: inc/class-ajax.php:151
 msgid "Key name cannot be empty."
 msgstr ""
 
-#: inc/class-ajax.php:156
+#: inc/class-ajax.php:160
 msgid "Failed to rename the key."
 msgstr ""
 
@@ -157,6 +161,10 @@ msgstr ""
 
 #: inc/class-webauthn-provider.php:107
 msgid "Unable to retrieve the authentication context."
+msgstr ""
+
+#: inc/class-webauthn-user.php:52
+msgid "Unable to save the user handle to the database."
 msgstr ""
 
 #: views/login.php:2


### PR DESCRIPTION
Chrome on Mac seems to generate long credential IDs (> 128 bytes). The `credential_id` column is too short for them, which makes it impossible to store such a credential.