### PR TITLE
Fix DB table prefix when used on multisite

### DIFF
--- a/inc/class-schema.php
+++ b/inc/class-schema.php
@@ -18,8 +18,14 @@ final class Schema {
 		/** @var wpdb $wpdb */
 		global $wpdb;
 
-		$wpdb->webauthn_credentials = $wpdb->prefix . Constants::WA_CREDENTIALS_TABLE_NAME;
-		$wpdb->webauthn_users       = $wpdb->prefix . Constants::WA_USERS_TABLE_NAME;
+		$prefix = $wpdb->prefix;
+
+		if ( is_multisite() ) {
+			$prefix = sprintf( '%s%d_', $wpdb->base_prefix, get_main_site_id() );
+		}
+
+		$wpdb->webauthn_credentials = $prefix . Constants::WA_CREDENTIALS_TABLE_NAME;
+		$wpdb->webauthn_users       = $prefix . Constants::WA_USERS_TABLE_NAME;
 	}
 
 	public function is_installed(): bool {

--- a/inc/class-schema.php
+++ b/inc/class-schema.php
@@ -18,14 +18,8 @@ final class Schema {
 		/** @var wpdb $wpdb */
 		global $wpdb;
 
-		$prefix = $wpdb->prefix;
-
-		if ( is_multisite() ) {
-			$prefix = sprintf( '%s%d_', $wpdb->base_prefix, get_main_site_id() );
-		}
-
-		$wpdb->webauthn_credentials = $prefix . Constants::WA_CREDENTIALS_TABLE_NAME;
-		$wpdb->webauthn_users       = $prefix . Constants::WA_USERS_TABLE_NAME;
+		$wpdb->webauthn_credentials = $wpdb->base_prefix . Constants::WA_CREDENTIALS_TABLE_NAME;
+		$wpdb->webauthn_users       = $wpdb->base_prefix . Constants::WA_USERS_TABLE_NAME;
 	}
 
 	public function is_installed(): bool {


### PR DESCRIPTION
Hi, came across a bug when the WebAuthn plugin is network-activated on a multisite install.

Currently without this PR, if you visit a sub-site's admin profile page at `sub-site.example.com/wp-admin/profile.php`, the plugin will throw fatal `Table doesn't exist` errors.

The issue is In the `Schema` class, the DB table prefix should be global, rather than per-site.  For this PR, I've changed the prefix so the schema references the main site's DB tables for those that have already installed the plugin on multisite.

Let me know what you think.