### PR TITLE
Set the WebAuthN rpId to the COOKIE_DOMAIN if set

### DIFF
--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -32,8 +32,8 @@ abstract class Utils {
 	public static function create_webauthn_server(): ServerInterface {
 		$builder = new ServerBuilder();
 		$relay   = new RelyingParty( get_bloginfo( 'name' ), self::get_u2f_app_id() );
-		if ( COOKIE_DOMAIN ) {
-			$relay->setId( ltrim( COOKIE_DOMAIN, '.' ) );
+		if ( \COOKIE_DOMAIN ) {
+			$relay->setId( ltrim( \COOKIE_DOMAIN, '.' ) );
 		}
 		$builder->setRelyingParty( $relay );
 		$builder->setCredentialStore( new WebAuthn_Credential_Store() );

--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -31,7 +31,11 @@ abstract class Utils {
 
 	public static function create_webauthn_server(): ServerInterface {
 		$builder = new ServerBuilder();
-		$builder->setRelyingParty( new RelyingParty( get_bloginfo( 'name' ), self::get_u2f_app_id() ) );
+		$relay   = new RelyingParty( get_bloginfo( 'name' ), self::get_u2f_app_id() );
+		if ( COOKIE_DOMAIN ) {
+			$relay->setId( ltrim( COOKIE_DOMAIN, '.' ) );
+		}
+		$builder->setRelyingParty( $relay );
 		$builder->setCredentialStore( new WebAuthn_Credential_Store() );
 		$builder->enableExtensions( 'appid' );
 		return $builder->build();


### PR DESCRIPTION
By default the WebAuthN Passkey is scoped to the origin domain, for example, example.org

If a Multisite install however shares it's cookies with subdomains, attempting to login via subdomain.example.org will fail to match as the origin doesn't match the keys ID.

On single-site, COOKIE_DOMAIN is normally false. On Multisite, it's usually set to either a) The domain, or b) on subdomains, the parent domain. The ltrim() is used for sites that support older browsers which needed the leading `.`.

This allows for the WebAuthN Passkey to be setup via a subdomain or the parent domain, and used on all of it's subdomains or parent domain.

**Minimal testing has been done, and further testing is required.**

Fixes #456