### PR TITLE
Use the text "Use your security key" as the alternate provider text on the login screen.

### DIFF
--- a/inc/class-webauthn-provider.php
+++ b/inc/class-webauthn-provider.php
@@ -50,6 +50,13 @@ class WebAuthn_Provider extends Two_Factor_Provider {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function get_alternative_provider_label() {
+		return _x( 'Use your security key', 'Provider label', 'two-factor-provider-webauthn' );
+	}
+
+	/**
 	 * @param WP_User $user
 	 * @return void
 	 */


### PR DESCRIPTION
See https://github.com/WordPress/two-factor/pull/521 for the change in the upcoming 0.9 release of Two-Factor.

Examples:
| Before | After |
| --- | --- |
| <img width="410" alt="Screenshot 2023-05-17 at 3 57 18 pm" src="https://github.com/sjinks/wp-two-factor-provider-webauthn/assets/767313/81ea885c-52cc-4aaa-977d-5566519f222b"> | <img width="414" alt="Screenshot 2023-05-17 at 3 56 51 pm" src="https://github.com/sjinks/wp-two-factor-provider-webauthn/assets/767313/ad181f17-6473-4587-8854-a0a11ca52433"> |

I wasn't sure about the translation context, but it seems reasonable to call this a provider label.