### PR TITLE
feat: Add a hook to customize WebAuthN server

### DIFF
--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -41,6 +41,9 @@ abstract class Utils {
 		$builder->setRelyingParty( $party );
 		$builder->setCredentialStore( new WebAuthn_Credential_Store() );
 		$builder->enableExtensions( 'appid' );
+
+		do_action( 'tfa_webauthn_init_server', $builder );
+
 		return $builder->build();
 	}
 


### PR DESCRIPTION
This PR adds a hook, `tfa_webauthn_init_server`, to allow for customization of the WebAuthN server.

Ref: https://github.com/sjinks/wp-two-factor-provider-webauthn/pull/457#discussion_r1189275301