### PR TITLE
ci: disable file monitoring for Build JS workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: block
+          disable-file-monitoring: true
           allowed-endpoints: >
             api.github.com:443
             github.com:443


### PR DESCRIPTION
`npm run build` overwrites `two-factor-provider-webauthn-js.pot` and may overwrite the generated JS files.