### PR TITLE
ci: remove unmaintained images and PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "7.4"
           - "8.0"
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         dependencies:
           - lowest
           - locked

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,12 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         wordpress:
-          - php8.0
           - php8.1
           - php8.2
-          - beta-php8.0
-          - beta-php8.1
-          - beta-php8.2
+          - php8.3
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c95a14d0e5bab51a9f56296a4eb0e416910cd350 # v2.10.3


### PR DESCRIPTION
* Remove PHP 7.4 from the CI workflow (EoL was two years ago);
* Add PHP 8.4 to the CI workflow;
* Remove `beta-*` images from the E2E workflow (WordPress does not build them anymore 😞);
* Remove `php8.0` image from the E2E workflow (WordPress does not update it anymore);
* Add `php8.3` image to the E2E workflow.
