### PR TITLE
fix: do not set `two_factor_providers` filter if installation failed

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -24,7 +24,11 @@ final class Plugin {
 
 	public function init(): void {
 		load_plugin_textdomain( 'two-factor-provider-webauthn', false, plugin_basename( dirname( __DIR__ ) ) . '/lang/' );
-		add_filter( 'two_factor_providers', [ $this, 'two_factor_providers' ] );
+
+		$schema = Schema::instance();
+		if ( $schema->is_installed() ) {
+			add_filter( 'two_factor_providers', [ $this, 'two_factor_providers' ] );
+		}
 
 		if ( is_admin() ) {
 			Admin::instance();


### PR DESCRIPTION
Fixes: #898 

If the plugin fails to install its tables, do not set the `two_factor_providers` filter hook to avoid surprises.
