### PR TITLE
ci: install subversion

### DIFF
--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Check out
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Install subversion
+        run: sudo apt-get update && sudo apt-get -y install subversion
+
       - name: Install dependencies to bundle
         run: |
           composer install --no-dev --no-interaction


### PR DESCRIPTION
Recent `ubuntu-latest` images come without `svn`; this breaks deployments.
