### PR TITLE
fix: conflicts when autoloading files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
 			"php": "8.0"
 		},
 		"optimize-autoloader": true,
-		"classmap-authoritative": true
+		"classmap-authoritative": true,
+		"autoloader-suffix": "WWTFWA"
 	},
 	"extra": {
 		"imposter": {
@@ -56,6 +57,9 @@
 				"Fix client extension verification (GH-295)": "patches/client-extensions.patch",
 				"Fix EdDSA keys/improve YubiKey support": "patches/gh-541.patch",
 				"Fix Firefox iCloud support": "patches/webauthn-icloud.patch"
+			},
+			"guzzlehttp/guzzle": {
+				"Fix namespace in check": "patches/guzzle.patch"
 			}
 		}
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9639c7c42179e69be103b1f066072c3b",
+    "content-hash": "fd370ecbd463b874f705898856e76a1e",
     "packages": [
         {
             "name": "composer/installers",
@@ -3548,16 +3548,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.5",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082"
+                "reference": "80ccb1a7640995edf1b87a4409fa584cd5869469"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
-                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/80ccb1a7640995edf1b87a4409fa584cd5869469",
+                "reference": "80ccb1a7640995edf1b87a4409fa584cd5869469",
                 "shasum": ""
             },
             "require": {
@@ -3614,7 +3614,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-24T21:37:59+00:00"
+            "time": "2025-01-16T22:34:19+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -6022,13 +6022,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.0.0"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.0"
     },

--- a/index.php
+++ b/index.php
@@ -14,11 +14,17 @@ use Composer\Autoload\ClassLoader;
 use WildWolf\WordPress\TwoFactorWebAuthn\Plugin;
 
 if ( defined( 'ABSPATH' ) ) {
+	/** @var mixed */
+	$save = $GLOBALS['__composer_autoload_files'] ?? null;
+
 	/** @var ClassLoader */
 	$loader = require __DIR__ . '/vendor/autoload.php'; // NOSONAR
 	$loader->addClassMap( [
 		WP_List_Table::class => ABSPATH . 'wp-admin/includes/class-wp-list-table.php',
 	] );
+
+	/** @psalm-suppress MixedAssignment */
+	$GLOBALS['__composer_autoload_files'] = $save;
 
 	if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
 		Plugin::instance();

--- a/patches/guzzle.patch
+++ b/patches/guzzle.patch
@@ -1,0 +1,10 @@
+--- src/functions_include.php	2025-01-17 11:39:43.072206414 +0200
++++ src/functions_include.php	2025-01-17 11:40:14.455385052 +0200
+@@ -1,6 +1,6 @@
+ <?php
+ 
+ // Don't redefine the functions if included multiple times.
+-if (!\function_exists('GuzzleHttp\describe_type')) {
++if (!\function_exists('\\WildWolf\\WordPress\\TwoFactorWebAuthn\\Vendor\\GuzzleHttp\\describe_type')) {
+     require __DIR__.'/functions.php';
+ }


### PR DESCRIPTION
This could fix #36 and #53.

The issue: when several packages declare a dependency on another package, and that package has the `autoload.files` key, `composer` may load only one file. This happens because `composer` takes the hash of the package name and a relative path to the file and uses that hash to ensure that the file is not loaded more than once.

Because we prefix all dependencies, it can happen that `composer` loads our version of the file and does not load the original one. This is the case with Guzzle's `functions_include.php`.

As a quick workaround, we restore the original value of the `__composer_autoload_files` global after invoking the autoloader.

I am also looking for a more robust solution.
