### PR TITLE
fix: restore `WebAuthn_Provider::get_instance()`

### DIFF
--- a/inc/class-webauthn-provider.php
+++ b/inc/class-webauthn-provider.php
@@ -19,6 +19,20 @@ use WildWolf\WordPress\TwoFactorWebAuthn\Vendor\{
 class WebAuthn_Provider extends Two_Factor_Provider {
 	public const AUTHENTICATION_CONTEXT_USER_META = Constants::AUTHENTICATION_CONTEXT_USER_META_KEY;
 
+	/** @var static|null */
+	private static $instance = null;
+
+	/**
+	 * @return static
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new static();
+		}
+
+		return self::$instance;
+	}
+
 	final protected function __construct() {
 		add_action( 'two_factor_user_options_TwoFactor_Provider_WebAuthn', [ $this, 'user_options' ] );
 		parent::__construct();

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: WebAuthn Provider for Two Factor
  * Description: WebAuthn Provider for Two Factor plugin.
- * Version: 2.5.2
+ * Version: 2.5.3
  * Author: Volodymyr Kolesnykov
  * License: MIT
  * Text Domain: two-factor-provider-webauthn

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "two-factor-provider-webauthn",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "two-factor-provider-webauthn",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.25.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "two-factor-provider-webauthn",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "description": "",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/donate/?hosted_button_id=SAG6877JDJ3KU
 Tags: 2fa, webauthn, two factor, login, security, authentication
 Requires at least: 5.5
 Tested up to: 6.7
-Stable tag: 2.5.2
+Stable tag: 2.5.3
 Requires PHP: 8.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
@@ -32,6 +32,9 @@ Be the first to ask.
 2. Plugin settings page.
 
 == Changelog ==
+
+= 2.5.3 =
+* Restore `WebAuthn_Provider::get_instance()` because WPVIP has an ancient version of Two Factor
 
 = 2.5.2 =
 * Fix the conflict when another package loads a library that has `autoload.files` key (see https://github.com/sjinks/wp-two-factor-provider-webauthn/pull/980)


### PR DESCRIPTION
Partially reverts c0198c8ab79bfcc169034296f57053c25d1cc99f

Restore `get_instance()` method because WPVIP environment has ancient Two Factor 0.8.2; `get_instance()` appeared in 0.9.0.
