### PR TITLE
ci: update the list of allowed endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,14 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             azure.archive.ubuntu.com:80
+            dl.cloudsmith.io:443
+            getcomposer.org:443
             github.com:443
             objects.githubusercontent.com:443
             packagist.org:443
+            release-assets.githubusercontent.com:443
             repo.packagist.org:443
+            setup-php.com:443
 
       - name: Checkout source code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,10 +36,14 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             api.wordpress.org:443
+            api.wordpress.org:80
             auth.docker.io:443
             azure.archive.ubuntu.com:80
+            cdn.jsdelivr.net:443
             cdn.playwright.dev:443
+            dl.cloudsmith.io:443
             downloads.wordpress.org:443
+            getcomposer.org:443
             github.com:443
             objects.githubusercontent.com:443
             packagist.org:443
@@ -48,11 +52,14 @@ jobs:
             phar.phpunit.de:443
             planet.wordpress.org:443
             playwright.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
             production.cloudflare.docker.com:443
             registry-1.docker.io:443
             registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
             repo.packagist.org:443
             secure.gravatar.com:443
+            setup-php.com:443
             wordpress.org:443
 
       - name: Checkout source code
@@ -109,15 +116,16 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             packagist.org:443
-            repo.packagist.org:443
             pecl.php.net:443
             pecl.php.net:80
             phar.phpunit.de:443
             planet.wordpress.org:443
             playwright.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
             production.cloudflare.docker.com:443
             registry-1.docker.io:443
             registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
             repo.packagist.org:443
             secure.gravatar.com:443
             wordpress.org:443

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
             objects.githubusercontent.com:443
             packagist.org:443
             repo.packagist.org:443
+            setup-php.com:443
 
       - name: Check out source code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -29,10 +29,16 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             azure.archive.ubuntu.com:80
+            cdn.fwupd.org:443
+            cdn.jsdelivr.net:443
+            dl.cloudsmith.io:443
+            getcomposer.org:443
             github.com:443
             objects.githubusercontent.com:443
             packagist.org:443
+            release-assets.githubusercontent.com:443
             repo.packagist.org:443
+            setup-php.com:443
 
       - name: Check out source code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This pull request updates the `allowed-endpoints` lists across multiple GitHub Actions workflow files to include additional endpoints required for dependencies and tools. These changes ensure smoother CI/CD processes by explicitly allowing necessary network connections.

### Updates to `allowed-endpoints` in workflows:

#### CI Workflow (`.github/workflows/ci.yml`):
* Added `dl.cloudsmith.io:443`, `getcomposer.org:443`, `release-assets.githubusercontent.com:443`, and `setup-php.com:443` to the `allowed-endpoints` list.

#### E2E Workflow (`.github/workflows/e2e.yml`):
* Added `api.wordpress.org:80`, `cdn.jsdelivr.net:443`, `dl.cloudsmith.io:443`, `getcomposer.org:443`, `playwright.download.prss.microsoft.com:443`, `release-assets.githubusercontent.com:443`, and `setup-php.com:443` to the `allowed-endpoints` list. [[1]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eR39-R46) [[2]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eR55-R62)
* Removed duplicate `repo.packagist.org:443` entry from the `allowed-endpoints` list.

#### Lint Workflow (`.github/workflows/lint.yml`):
* Added `setup-php.com:443` to the `allowed-endpoints` list.

#### Static Code Analysis Workflow (`.github/workflows/static-code-analysis.yml`):
* Added `cdn.fwupd.org:443`, `cdn.jsdelivr.net:443`, `dl.cloudsmith.io:443`, `getcomposer.org:443`, `release-assets.githubusercontent.com:443`, and `setup-php.com:443` to the `allowed-endpoints` list.