### PR TITLE
fix(test): save profile after enabling WebAuthn provider in login workflow

### DIFF
--- a/tests/e2e/specs/login.spec.ts
+++ b/tests/e2e/specs/login.spec.ts
@@ -34,6 +34,7 @@ test('Login Workflow', async ({ page }) => {
 		expect(page.url()).toContain('/wp-admin/profile.php');
 		const profilePage = new ProfilePage(page);
 		await profilePage.enableWebAuthnProvider();
+		await profilePage.saveProfile();
 		await profilePage.makeWebAuthnProviderPrimary();
 		return profilePage.saveProfile();
 	});


### PR DESCRIPTION
This pull request includes a minor update to the `tests/e2e/specs/login.spec.ts` file. The change ensures that the profile is saved after enabling the WebAuthn provider in the login workflow test.

* [`tests/e2e/specs/login.spec.ts`](diffhunk://#diff-fc5d2d0803669060e912e298c86090a13272207de5bbaa66171eec180a750e3aR37): Added a call to `saveProfile()` immediately after enabling the WebAuthn provider to ensure changes are persisted.