### PR TITLE
style: fix linting issues

### DIFF
--- a/inc/class-credential-migrator.php
+++ b/inc/class-credential-migrator.php
@@ -27,7 +27,7 @@ abstract class Credential_Migrator {
 		global $wpdb;
 
 		/** @var mixed[] */
-		$legacy = get_user_meta( $user->ID, WebAuthn_Credential_Store::REGISTERED_KEY_LEGACY_META );
+		$legacy = get_user_meta( $user->ID, WebAuthn_Credential_Store::REGISTERED_KEY_LEGACY_META, false );
 
 		/** @var mixed $data */
 		foreach ( $legacy as $data ) {

--- a/inc/class-webauthn-credential-store.php
+++ b/inc/class-webauthn-credential-store.php
@@ -96,7 +96,7 @@ final class WebAuthn_Credential_Store implements CredentialStoreInterface {
 		$modern = $handle ? $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->webauthn_credentials} WHERE user_handle = %s", $handle->toString() ) ) : [];
 		if ( empty( $modern ) ) {
 			/** @var array */
-			$legacy = get_user_meta( $user->ID, self::REGISTERED_KEY_LEGACY_META );
+			$legacy = get_user_meta( $user->ID, self::REGISTERED_KEY_LEGACY_META, false );
 			if ( ! empty( $legacy ) ) {
 				if ( ! $handle ) {
 					$handle = $wauser->generate_and_save_handle();


### PR DESCRIPTION
This pull request makes two changes to improve the handling of legacy user metadata by ensuring that the `get_user_meta` function retrieves all matching metadata entries, rather than just the first one. This adjustment ensures consistency and correctness when working with user metadata arrays.

### Improvements to metadata retrieval:

* [`inc/class-credential-migrator.php`](diffhunk://#diff-0684713b27f992a5288159bd0e43014fda84a1d058f19bafbf7ce48f008e3463L30-R30): Updated the `migrate` method to pass `false` as the third parameter to `get_user_meta`, ensuring all metadata entries are retrieved for the legacy keys.
* [`inc/class-webauthn-credential-store.php`](diffhunk://#diff-47e6a8fffd0563741f28ea4d088899a66564fa6653741f160c6298aff6190a7aL99-R99): Updated the `get_user_keys` method to include the `false` parameter in the `get_user_meta` call, ensuring all legacy metadata entries are fetched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy credential data to ensure all user entries are correctly retrieved and processed. This enhances reliability when migrating and accessing legacy credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->