### PR TITLE
ci: update PHP versions

### DIFF
--- a/.docker/wordpress/Dockerfile
+++ b/.docker/wordpress/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=php8.0@sha256:824689613b4e7b027d0d36f264a53a159d6c7adcf5250539e56efe2940651e19
+ARG VERSION=php8.1
 FROM wordpress:${VERSION}
 RUN \
     a2enmod ssl && \

--- a/.docker/wordpress/Dockerfile
+++ b/.docker/wordpress/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=php8.1
+ARG VERSION=php8.3
 FROM wordpress:${VERSION}
 RUN \
     a2enmod ssl && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "8.0"
           - "8.1"
           - "8.2"
           - "8.3"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,7 @@ jobs:
           - php8.1
           - php8.2
           - php8.3
+          - php8.4
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       context: .docker/wordpress
       dockerfile: Dockerfile
       args:
-        VERSION: ${WP_VERSION:-php8.0}
+        VERSION: ${WP_VERSION:-php8.3}
     depends_on:
       - mariadb
     ports:


### PR DESCRIPTION
This pull request updates the PHP version used across the project to align with newer versions and ensures compatibility with the latest PHP releases. The changes primarily focus on upgrading from PHP 8.0 to PHP 8.3 in various configurations and adding support for PHP 8.4 in end-to-end testing.

### PHP version updates:

* [`.docker/wordpress/Dockerfile`](diffhunk://#diff-425855e0c01f4ebef64c7f8f12314b152f751d3a1ab41b86675b63f5cab94a2dL1-R1): Updated the default PHP version from `php8.0` to `php8.3`.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L16-R16): Adjusted the `VERSION` argument to default to `php8.3` instead of `php8.0`.

### CI and testing updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25): Removed PHP 8.0 from the test matrix and added PHP 8.3.
* [`.github/workflows/e2e.yml`](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eR30): Added support for PHP 8.4 in the end-to-end testing matrix.