### PR TITLE
fix: function call order

### DIFF
--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -52,7 +52,7 @@ abstract class Utils {
 	public static function get_post_field_as_string( string $field ): string {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ $field ] ) && is_scalar( $_POST[ $field ] ) ) {
-			return wp_unslash( sanitize_text_field( (string) $_POST[ $field ] ) );
+			return sanitize_text_field( wp_unslash( (string) $_POST[ $field ] ) );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 


### PR DESCRIPTION
This pull request updates the order of sanitization and unescaping functions in the `get_post_field_as_string` method. This change ensures that data is first unescaped and then sanitized, which aligns with WordPress best practices.